### PR TITLE
Refactor/#33-imageUpdate

### DIFF
--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/user/service/ImageUpdateService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/user/service/ImageUpdateService.java
@@ -9,7 +9,9 @@ import com.ttodampartners.ttodamttodam.domain.user.util.AuthenticationUtil;
 import com.ttodampartners.ttodamttodam.global.error.ErrorCode;
 import com.ttodampartners.ttodamttodam.domain.user.exception.AwsException;
 import java.io.IOException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ImageUpdateService {
   private final AmazonS3 amazonS3;
@@ -26,26 +29,43 @@ public class ImageUpdateService {
   private String bucket;
 
   @Transactional
-  public void imageUpdate(Long userId, MultipartFile file) {
+  public void imageUpdate(Long userId, MultipartFile newImage) {
     UserEntity user = getUser(userId);
     isMatchEmail(user);
 
-    user.setProfileImgUrl(saveFile(file));
+    String oldImage = user.getProfileImgUrl();  // 기존 image 빼오기
+    user.setProfileImgUrl(saveFile(newImage));  // 새 이미지 s3 및 UserEntity 에 url 저장
+    deleteOldProfileImage(oldImage);            // 기존 image s3에서 삭제
   }
-  private String saveFile(MultipartFile multipartFile) {
+
+  private String saveFile(MultipartFile newImage) {
     try {
-      String originalFilename = multipartFile.getOriginalFilename();
+      String uploadImageName = UUID.randomUUID().toString();
 
       ObjectMetadata metadata = new ObjectMetadata();
-      metadata.setContentLength(multipartFile.getSize());
-      metadata.setContentType(multipartFile.getContentType());
+      metadata.setContentLength(newImage.getSize());
+      metadata.setContentType(newImage.getContentType());
 
-      amazonS3.putObject(bucket, originalFilename, multipartFile.getInputStream(), metadata);
+      amazonS3.putObject(bucket, uploadImageName, newImage.getInputStream(), metadata);
 
-      return amazonS3.getUrl(bucket, originalFilename).toString();
+      return amazonS3.getUrl(bucket, uploadImageName).toString();
     } catch (IOException e) {
       throw new AwsException(ErrorCode.UPLOAD_FAILED);
     }
+  }
+
+  private void deleteOldProfileImage(String oldImage) {
+    // 프로필에 사진이 존재했다면 S3에서 삭제
+    if (oldImage != null) {
+      oldImage = getImageFileNameFromUrl(oldImage);
+      amazonS3.deleteObject(bucket, oldImage);
+    }
+  }
+
+  private String getImageFileNameFromUrl (String imageUrl) {
+    // URL 에서 파일 이름 추출 (예: https://example.com/images/profile.jpg -> profile.jpg)
+    String[] parts = imageUrl.split("/");
+    return parts[parts.length - 1];
   }
 
   private UserEntity getUser(Long userId) {

--- a/src/test/java/com/ttodampartners/ttodamttodam/domain/user/controller/ImageUpdateControllerTest.java
+++ b/src/test/java/com/ttodampartners/ttodamttodam/domain/user/controller/ImageUpdateControllerTest.java
@@ -1,0 +1,44 @@
+package com.ttodampartners.ttodamttodam.domain.user.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+
+import com.ttodampartners.ttodamttodam.domain.user.service.ImageUpdateService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("이미지 업데이트 컨트롤러 테스트")
+class ImageUpdateControllerTest {
+
+  @Mock
+  ImageUpdateService imageUpdateService;
+
+  @InjectMocks
+  ImageUpdateController imageUpdateController;
+
+  @Test
+  void imageUpdateTest() {
+    //given
+    Long userId = 1L;
+    MultipartFile file = new MockMultipartFile("file", "test.jpg",
+        "image/jpeg", new byte[0]);
+
+    //when
+    doNothing().when(imageUpdateService).imageUpdate(any(Long.class), any(MultipartFile.class));
+    ResponseEntity<String> response = imageUpdateController.imageUpdate(userId, file);
+
+    //then
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals("정상적으로 수정되었습니다.", response.getBody());
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
프로필 사진 수정 시 파일명을 UUID를 이용해 중복 없이 저장되도록 수정
프로필 사진 수정 시 유저의 기존 프로필이 존재한다면 해당 URL을 통해 파일명을 가져와 S3에서 삭제하는 로직 추가
**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
 - Controller 테스트 진행
- [x] API 테스트