### PR TITLE
Fix/#25 Stomp 연결 시 JWT 검사 

### DIFF
--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompConfig.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompConfig.java
@@ -1,18 +1,23 @@
 package com.ttodampartners.ttodamttodam.domain.chat.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 /*
-* Stomp를 사용하기 위한 설정 파일
-* */
+    Stomp를 사용하기 위한 설정 파일
+*/
 
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 @Configuration
 public class StompConfig implements WebSocketMessageBrokerConfigurer {
+    private final StompHandler stompHandler;
+
     // Stomp 연결을 처리할 엔드포인트
     @Override
     public void registerStompEndpoints (StompEndpointRegistry registry) {
@@ -29,5 +34,11 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker (MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/chatroom"); // sub: 메시지 브로커가 Subscriber들에게 메시지를 전달할 URL 접두사
         registry.setApplicationDestinationPrefixes("/chattings"); // pub: 클라이언트가 서버로 메시지 보낼 URL 접두사
+    }
+
+    // 메시지를 Controller로 보내기 전 JWT 유효성 검사
+    @Override
+    public void configureClientInboundChannel (ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
     }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
@@ -40,6 +40,9 @@ public class StompHandler implements ChannelInterceptor {
             if (authorizationHeader == null) {
                 log.info("헤더가 없는 요청입니다.");
                 throw new IllegalArgumentException("JWT");
+            } else {
+                Long userId = Long.valueOf(tokenProvider.parseClaims(authorizationHeader).getId());
+                log.info("userId: {}", userId);
             }
 
             /*

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
@@ -1,0 +1,14 @@
+package com.ttodampartners.ttodamttodam.domain.chat.config;
+
+import com.ttodampartners.ttodamttodam.global.config.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.support.ChannelInterceptor;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class StompHandler implements ChannelInterceptor {
+    private final TokenProvider tokenProvider;
+}

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
@@ -3,7 +3,12 @@ package com.ttodampartners.ttodamttodam.domain.chat.config;
 import com.ttodampartners.ttodamttodam.global.config.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContextException;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 
 @Slf4j
@@ -11,4 +16,42 @@ import org.springframework.messaging.support.ChannelInterceptor;
 @Configuration
 public class StompHandler implements ChannelInterceptor {
     private final TokenProvider tokenProvider;
+
+    // 메시지 오면 JWT 유효성 검사
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        try {
+            // Stomp 메시지 객체의 헤더 접근
+            StompHeaderAccessor accessor = StompHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+            // 이름이 "Authorization"인 헤더
+            String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
+
+            StompCommand command = accessor.getCommand();
+
+            // [구독 취소, 메시지 수신, 메시지 송신, 연결 완료] 시에는 JWT 유효성 검사 X
+            if (command.equals(StompCommand.UNSUBSCRIBE) || command.equals(StompCommand.MESSAGE) ||
+                    command.equals(StompCommand.CONNECTED) || command.equals(StompCommand.SEND)) {
+                return message;
+            } else if (command.equals(StompCommand.ERROR)) {
+                // 추후 예외 처리 필요!!
+                throw new IllegalArgumentException("ERROR");
+            }
+
+            if (authorizationHeader == null) {
+                log.info("header가 없는 요청입니다.");
+                throw new IllegalArgumentException("JWT");
+            }
+
+            if (command.equals(StompCommand.SUBSCRIBE) || command.equals(StompCommand.CONNECT)) {
+                if (!tokenProvider.validateToken(authorizationHeader)) {
+                    // 추후 예외 처리 필요!!
+                    throw new IllegalArgumentException("토큰이 유효하지 않습니다.");
+                }
+            }
+        } catch (ApplicationContextException e) {
+            log.error("JWT 에러");
+            throw new IllegalArgumentException("jwt");
+        }
+        return message;
+    }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
@@ -24,9 +24,9 @@ public class StompHandler implements ChannelInterceptor {
             // Stomp 메시지 객체의 헤더 접근
             StompHeaderAccessor accessor = StompHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
             // 이름이 "Authorization"인 헤더
-            String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
-
+            String authorizationHeader = String.valueOf(accessor.getNativeHeader("Authorization"));
             StompCommand command = accessor.getCommand();
+            log.info("HEADER: {}, COMMAND: {}", authorizationHeader, command);
 
             // [구독 취소, 메시지 수신, 메시지 송신, 연결 완료] 시에는 JWT 유효성 검사 X
             if (command.equals(StompCommand.UNSUBSCRIBE) || command.equals(StompCommand.MESSAGE) ||
@@ -38,10 +38,13 @@ public class StompHandler implements ChannelInterceptor {
             }
 
             if (authorizationHeader == null) {
-                log.info("header가 없는 요청입니다.");
+                log.info("헤더가 없는 요청입니다.");
                 throw new IllegalArgumentException("JWT");
             }
 
+            /*
+                authorizationHeader token 분리 필요할 수도 있음.
+            */
             if (command.equals(StompCommand.SUBSCRIBE) || command.equals(StompCommand.CONNECT)) {
                 if (!tokenProvider.validateToken(authorizationHeader)) {
                     // 추후 예외 처리 필요!!
@@ -49,6 +52,7 @@ public class StompHandler implements ChannelInterceptor {
                 }
             }
         } catch (ApplicationContextException e) {
+            // 추후 예외 처리 필요!!
             log.error("JWT 에러");
             throw new IllegalArgumentException("jwt");
         }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/config/StompHandler.java
@@ -1,10 +1,14 @@
 package com.ttodampartners.ttodamttodam.domain.chat.config;
 
+import com.ttodampartners.ttodamttodam.domain.chat.dto.ChatExceptionResponse;
+import com.ttodampartners.ttodamttodam.domain.chat.dto.response.StompExceptionResponse;
+import com.ttodampartners.ttodamttodam.domain.chat.exception.StompException;
 import com.ttodampartners.ttodamttodam.global.config.security.TokenProvider;
+import com.ttodampartners.ttodamttodam.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationContextException;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -26,9 +30,10 @@ public class StompHandler implements ChannelInterceptor {
             // 이름이 "Authorization"인 헤더
             String authorizationHeader = String.valueOf(accessor.getNativeHeader("Authorization"));
             StompCommand command = accessor.getCommand();
+
             log.info("HEADER: {}, COMMAND: {}", authorizationHeader, command);
 
-            // [구독 취소, 메시지 수신, 메시지 송신, 연결 완료] 시에는 JWT 유효성 검사 X
+            // [구독 취소, 메시지 수신, 메시지 송신, 연결 완료] 시에는 JWT 검사 X
             if (command.equals(StompCommand.UNSUBSCRIBE) || command.equals(StompCommand.MESSAGE) ||
                     command.equals(StompCommand.CONNECTED) || command.equals(StompCommand.SEND)) {
                 return message;
@@ -39,7 +44,9 @@ public class StompHandler implements ChannelInterceptor {
 
             if (authorizationHeader == null) {
                 log.info("헤더가 없는 요청입니다.");
-                throw new IllegalArgumentException("JWT");
+                ErrorCode code = ErrorCode.HEADER_NOT_FOUND;
+
+                throw new StompException(code, ChatExceptionResponse.res(HttpStatus.BAD_REQUEST, code.getDescription(), StompExceptionResponse.builder().command(command.toString()).build()));
             } else {
                 Long userId = Long.valueOf(tokenProvider.parseClaims(authorizationHeader).getId());
                 log.info("userId: {}", userId);
@@ -50,14 +57,16 @@ public class StompHandler implements ChannelInterceptor {
             */
             if (command.equals(StompCommand.SUBSCRIBE) || command.equals(StompCommand.CONNECT)) {
                 if (!tokenProvider.validateToken(authorizationHeader)) {
-                    // 추후 예외 처리 필요!!
-                    throw new IllegalArgumentException("토큰이 유효하지 않습니다.");
+                    // 추가적인 예외 처리 필요!!
+                    throw new IllegalArgumentException("jwt");
                 }
             }
-        } catch (ApplicationContextException e) {
-            // 추후 예외 처리 필요!!
+        } catch (RuntimeException e) {
             log.error("JWT 에러");
-            throw new IllegalArgumentException("jwt");
+
+            ErrorCode code = ErrorCode.INVALID_MESSAGE;
+
+            throw new StompException(code, ChatExceptionResponse.res(HttpStatus.BAD_REQUEST, code.getDescription(), StompExceptionResponse.builder().build()));
         }
         return message;
     }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatController.java
@@ -1,8 +1,11 @@
 package com.ttodampartners.ttodamttodam.domain.chat.controller;
 
 import com.ttodampartners.ttodamttodam.domain.chat.dto.request.ChatMessageRequest;
+import com.ttodampartners.ttodamttodam.domain.chat.exception.ChatroomStringException;
 import com.ttodampartners.ttodamttodam.domain.chat.repository.ChatroomRepository;
 import com.ttodampartners.ttodamttodam.domain.chat.service.ChatService;
+import com.ttodampartners.ttodamttodam.global.error.ErrorCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -23,9 +26,9 @@ public class ChatController {
     */
 
     @MessageMapping("/{chatroomId}/messages")
-    public void chat(@DestinationVariable Long chatroomId, ChatMessageRequest request) {
+    public void chat(@DestinationVariable Long chatroomId, @Valid ChatMessageRequest request) {
         // 채팅방 존재 여부 확인
-        chatroomRepository.findByChatroomId(chatroomId).orElseThrow(IllegalArgumentException::new);
+        chatroomRepository.findByChatroomId(chatroomId).orElseThrow(() -> new ChatroomStringException(ErrorCode.CHATROOM_NOT_FOUND));
 
         // 채팅 메시지 DB 저장
         chatService.saveChatMessage(chatroomId, request);

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatroomController.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatroomController.java
@@ -4,9 +4,11 @@ import com.ttodampartners.ttodamttodam.domain.chat.dto.request.ChatroomCreateReq
 import com.ttodampartners.ttodamttodam.domain.chat.dto.response.ChatroomListResponse;
 import com.ttodampartners.ttodamttodam.domain.chat.dto.response.ChatroomResponse;
 import com.ttodampartners.ttodamttodam.domain.chat.service.ChatroomService;
+import com.ttodampartners.ttodamttodam.global.dto.UserDetailsDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,21 +21,22 @@ public class ChatroomController {
     private final ChatroomService chatroomService;
 
     @PostMapping // POST /chatrooms (채팅방 생성)
-    public ResponseEntity<ChatroomResponse> createChatroom(@RequestBody ChatroomCreateRequest request) {
-        ChatroomResponse chatroomResponse = chatroomService.createChatroom(request);
+    public ResponseEntity<ChatroomResponse> createChatroom(@RequestBody ChatroomCreateRequest request, @AuthenticationPrincipal UserDetailsDto userDetailsDto) {
+        Long userId = userDetailsDto.getId();
+        ChatroomResponse chatroomResponse = chatroomService.createChatroom(request, userId);
          // ChatResponse 공통 응답 사용한다면 return 이렇게
          // return ResponseEntity.ok(ChatResponse.res(HttpStatus.OK, HttpStatus.OK.toString(), chatroomResponse));
         return ResponseEntity.ok(chatroomResponse);
     }
 
-    @GetMapping // GET /chatrooms?userId={userId} (채팅방 목록 조회)
-    public ResponseEntity<List<ChatroomListResponse>> getChatrooms(@RequestParam Long userId) {
-        List<ChatroomListResponse> chatroomListResponses = chatroomService.getChatrooms(userId);
+    @GetMapping // GET /chatrooms (채팅방 목록 조회)
+    public ResponseEntity<List<ChatroomListResponse>> getChatrooms(@AuthenticationPrincipal UserDetailsDto userDetailsDto) {
+        List<ChatroomListResponse> chatroomListResponses = chatroomService.getChatrooms(userDetailsDto.getId());
         return ResponseEntity.ok(chatroomListResponses);
     }
 
-    @DeleteMapping("/{chatroomId}/{userId}/exit") // DELETE /chatrooms/{chatroomId}/{userId}/exit (채팅방 나가기)
-    public void leaveChatroom(@PathVariable Long chatroomId, @PathVariable Long userId) {
-        chatroomService.leaveChatroom(chatroomId, userId);
+    @DeleteMapping("/{chatroomId}/exit") // DELETE /chatrooms/{chatroomId}/{userId}/exit (채팅방 나가기)
+    public void leaveChatroom(@PathVariable Long chatroomId, @AuthenticationPrincipal UserDetailsDto userDetailsDto) {
+        chatroomService.leaveChatroom(chatroomId, userDetailsDto.getId());
     }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatroomController.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatroomController.java
@@ -3,6 +3,7 @@ package com.ttodampartners.ttodamttodam.domain.chat.controller;
 import com.ttodampartners.ttodamttodam.domain.chat.dto.request.ChatroomCreateRequest;
 import com.ttodampartners.ttodamttodam.domain.chat.dto.response.ChatroomListResponse;
 import com.ttodampartners.ttodamttodam.domain.chat.dto.response.ChatroomResponse;
+import com.ttodampartners.ttodamttodam.domain.chat.service.ChatroomLeaveService;
 import com.ttodampartners.ttodamttodam.domain.chat.service.ChatroomService;
 import com.ttodampartners.ttodamttodam.global.dto.UserDetailsDto;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import java.util.List;
 @RestController
 public class ChatroomController {
     private final ChatroomService chatroomService;
+    private final ChatroomLeaveService chatroomLeaveService;
 
     @PostMapping // POST /chatrooms (채팅방 생성)
     public ResponseEntity<ChatroomResponse> createChatroom(@RequestBody ChatroomCreateRequest request, @AuthenticationPrincipal UserDetailsDto userDetailsDto) {
@@ -37,6 +39,6 @@ public class ChatroomController {
 
     @DeleteMapping("/{chatroomId}/exit") // DELETE /chatrooms/{chatroomId}/{userId}/exit (채팅방 나가기)
     public void leaveChatroom(@PathVariable Long chatroomId, @AuthenticationPrincipal UserDetailsDto userDetailsDto) {
-        chatroomService.leaveChatroom(chatroomId, userDetailsDto.getId());
+        chatroomLeaveService.leaveChatroom(chatroomId, userDetailsDto.getId());
     }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/request/ChatMessageRequest.java
@@ -1,5 +1,6 @@
 package com.ttodampartners.ttodamttodam.domain.chat.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,7 +12,9 @@ public class ChatMessageRequest {
     }
 
     private MessageType type;
+    @NotBlank(message = "송신자 id가 존재하지 않습니다.")
     private Long senderId;
     private String nickname;
+    @NotBlank(message = "채팅 내용이 없습니다.")
     private String content;
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/request/ChatMessageRequest.java
@@ -13,7 +13,7 @@ public class ChatMessageRequest {
 
     private MessageType type;
     @NotBlank(message = "송신자 id가 존재하지 않습니다.")
-    private Long senderId;
+//    private Long senderId;
     private String nickname;
     @NotBlank(message = "채팅 내용이 없습니다.")
     private String content;

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/request/ChatroomCreateRequest.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/request/ChatroomCreateRequest.java
@@ -13,6 +13,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class ChatroomCreateRequest {
-    private Long userId;
     private Long postId;
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/response/StompExceptionResponse.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/response/StompExceptionResponse.java
@@ -1,0 +1,15 @@
+package com.ttodampartners.ttodamttodam.domain.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class StompExceptionResponse {
+    private String header;
+    private String command;
+}

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/entity/ChatroomMemberEntity.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/entity/ChatroomMemberEntity.java
@@ -47,6 +47,7 @@ public class ChatroomMemberEntity {
         return ChatroomListResponse.builder()
                 .chatroomId(userChatroom.getChatroomId())
                 .chatName(userChatroomPost.getTitle())
+                .product(userChatroomPost.getProducts().toString())
                 .hostId(userChatroomPost.getUser().getId())
                 .hostNickname(userChatroomPost.getUser().getNickname())
                 .userCount(userChatroom.getUserCount())

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/exception/StompException.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/exception/StompException.java
@@ -1,0 +1,24 @@
+package com.ttodampartners.ttodamttodam.domain.chat.exception;
+
+import com.ttodampartners.ttodamttodam.domain.chat.dto.ChatExceptionResponse;
+import com.ttodampartners.ttodamttodam.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StompException extends RuntimeException{
+    private ErrorCode errorCode;
+    private String errorMessage;
+    private ChatExceptionResponse response;
+
+    public StompException(ErrorCode errorCode, ChatExceptionResponse response) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+        this.response = response;
+    }
+}

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatService.java
@@ -28,8 +28,8 @@ public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
 
     @Transactional // 채팅 메시지 저장
-    public void saveChatMessage(Long chatroomId, ChatMessageRequest request) {
-        UserEntity user = userRepository.findById(request.getSenderId()).orElseThrow(IllegalArgumentException::new);
+    public void saveChatMessage(Long chatroomId, ChatMessageRequest request, Long senderId) {
+        UserEntity user = userRepository.findById(senderId).orElseThrow(IllegalArgumentException::new);
         ChatroomEntity chatroom = chatroomRepository.findByChatroomId(chatroomId).orElseThrow(IllegalArgumentException::new);
 
         // CHAT_MESSAGE 테이블에 insert

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomLeaveService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomLeaveService.java
@@ -1,0 +1,39 @@
+package com.ttodampartners.ttodamttodam.domain.chat.service;
+
+import com.ttodampartners.ttodamttodam.domain.chat.dto.ChatExceptionResponse;
+import com.ttodampartners.ttodamttodam.domain.chat.entity.ChatroomEntity;
+import com.ttodampartners.ttodamttodam.domain.chat.entity.ChatroomMemberEntity;
+import com.ttodampartners.ttodamttodam.domain.chat.exception.ChatroomException;
+import com.ttodampartners.ttodamttodam.domain.chat.exception.ChatroomStringException;
+import com.ttodampartners.ttodamttodam.domain.chat.repository.ChatroomMemberRepository;
+import com.ttodampartners.ttodamttodam.domain.chat.repository.ChatroomRepository;
+import com.ttodampartners.ttodamttodam.domain.user.entity.UserEntity;
+import com.ttodampartners.ttodamttodam.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ttodampartners.ttodamttodam.global.error.ErrorCode.CHATROOM_NOT_FOUND;
+import static com.ttodampartners.ttodamttodam.global.error.ErrorCode.USER_NOT_IN_CHATROOM;
+
+@RequiredArgsConstructor
+@Service
+public class ChatroomLeaveService {
+    private final UserRepository userRepository;
+    private final ChatroomRepository chatroomRepository;
+    private final ChatroomMemberRepository chatroomMemberRepository;
+
+    // 유저가 속한 chatroomId 채팅방 나가기
+    @Transactional
+    public void leaveChatroom(Long chatroomId, Long userId) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
+        ChatroomEntity chatroom = chatroomRepository.findByChatroomId(chatroomId).orElseThrow(() -> new ChatroomStringException(CHATROOM_NOT_FOUND));
+
+        ChatroomMemberEntity userChatroom = chatroomMemberRepository.findByUserEntityAndChatroomEntity(user, chatroom).orElseThrow(
+                () -> new ChatroomException(USER_NOT_IN_CHATROOM, ChatExceptionResponse.res(HttpStatus.BAD_REQUEST, USER_NOT_IN_CHATROOM.getDescription()))
+        );
+
+        chatroomMemberRepository.delete(userChatroom);
+    }
+}

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
@@ -110,7 +110,7 @@ public class ChatroomService {
     @Transactional
     public void leaveChatroom(Long chatroomId, Long userId) {
         UserEntity user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
-        ChatroomEntity chatroom = chatroomRepository.findByChatroomId(chatroomId).orElseThrow(() -> new ChatroomStringException(CHATROOM_NOT_EXIST));
+        ChatroomEntity chatroom = chatroomRepository.findByChatroomId(chatroomId).orElseThrow(() -> new ChatroomStringException(CHATROOM_NOT_FOUND));
 
         ChatroomMemberEntity userChatroom = chatroomMemberRepository.findByUserEntityAndChatroomEntity(user, chatroom).orElseThrow(
                 () -> new ChatroomException(USER_NOT_IN_CHATROOM, ChatExceptionResponse.res(HttpStatus.BAD_REQUEST, USER_NOT_IN_CHATROOM.getDescription()))

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
@@ -84,7 +84,8 @@ public class ChatroomService {
 
         return ChatroomResponse.builder()
                 .chatroomId(chatroom.getChatroomId())
-                .hostId(post.getUser().getId()).userCount(2)
+                .hostId(post.getUser().getId())
+                .userCount(2)
                 .chatName(post.getTitle())
                 .createAt(chatroom.getCreateAt())
                 .profiles(profileList)
@@ -104,19 +105,6 @@ public class ChatroomService {
         }
 
         return userChatrooms.stream().map(ChatroomMemberEntity::getChatroomInfos).toList();
-    }
-
-    // 유저가 속한 chatroomId 채팅방 나가기
-    @Transactional
-    public void leaveChatroom(Long chatroomId, Long userId) {
-        UserEntity user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
-        ChatroomEntity chatroom = chatroomRepository.findByChatroomId(chatroomId).orElseThrow(() -> new ChatroomStringException(CHATROOM_NOT_FOUND));
-
-        ChatroomMemberEntity userChatroom = chatroomMemberRepository.findByUserEntityAndChatroomEntity(user, chatroom).orElseThrow(
-                () -> new ChatroomException(USER_NOT_IN_CHATROOM, ChatExceptionResponse.res(HttpStatus.BAD_REQUEST, USER_NOT_IN_CHATROOM.getDescription()))
-        );
-
-        chatroomMemberRepository.delete(userChatroom);
     }
 
     /*

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
@@ -41,9 +41,9 @@ public class ChatroomService {
     // 일대일 개인 채팅방 생성 -> response body 반환
     // 추후 게시글 상태 '모집중'인지 체크!!
     @Transactional
-    public ChatroomResponse createChatroom(ChatroomCreateRequest request) {
+    public ChatroomResponse createChatroom(ChatroomCreateRequest request, Long userId) {
         // 문의자
-        UserEntity user = userRepository.findById(request.getUserId()).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
+        UserEntity user = userRepository.findById(userId).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
 
         PostEntity post = postRepository.findById(request.getPostId()).orElseThrow(IllegalArgumentException::new);
         // 게시글 작성자

--- a/src/main/java/com/ttodampartners/ttodamttodam/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/global/config/security/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                 .requestMatchers("/users/**").permitAll()
                 .requestMatchers("/login/**").permitAll()
                 .requestMatchers("/users/{userId}/**").authenticated()
+                .requestMatchers("/ws-chatting/**").permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
         );
     return http.build();

--- a/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
@@ -52,8 +52,13 @@ public enum ErrorCode {
   CHATROOM_ALREADY_EXIST("개인 채팅방이 이미 존재합니다."),
   USER_CHATROOM_NOT_EXIST("해당 유저가 속한 채팅방이 존재하지 않습니다."),
   USER_NOT_IN_CHATROOM("해당 유저가 채팅방에 속해있지 않아 채팅방을 나갈 수 없습니다."),
-  CHATROOM_NOT_FOUND("채팅방이 존재하지 않습니다.")
+  CHATROOM_NOT_FOUND("채팅방이 존재하지 않습니다."),
 
+  /*
+    Stomp Exception
+   */
+  INVALID_MESSAGE("유효하지 않은 메시지입니다."),
+  HEADER_NOT_FOUND("유효한 헤더가 존재하지 않습니다.")
   ;
 
 

--- a/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
   CHATROOM_ALREADY_EXIST("개인 채팅방이 이미 존재합니다."),
   USER_CHATROOM_NOT_EXIST("해당 유저가 속한 채팅방이 존재하지 않습니다."),
   USER_NOT_IN_CHATROOM("해당 유저가 채팅방에 속해있지 않아 채팅방을 삭제할 수 없습니다."),
-  CHATROOM_NOT_EXIST("채팅방이 존재하지 않습니다.")
+  CHATROOM_NOT_FOUND("채팅방이 존재하지 않습니다.")
 
   ;
 

--- a/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
@@ -51,7 +51,7 @@ public enum ErrorCode {
    */
   CHATROOM_ALREADY_EXIST("개인 채팅방이 이미 존재합니다."),
   USER_CHATROOM_NOT_EXIST("해당 유저가 속한 채팅방이 존재하지 않습니다."),
-  USER_NOT_IN_CHATROOM("해당 유저가 채팅방에 속해있지 않아 채팅방을 삭제할 수 없습니다."),
+  USER_NOT_IN_CHATROOM("해당 유저가 채팅방에 속해있지 않아 채팅방을 나갈 수 없습니다."),
   CHATROOM_NOT_FOUND("채팅방이 존재하지 않습니다.")
 
   ;

--- a/src/test/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomServiceTest.java
@@ -14,15 +14,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @DisplayName("개인 채팅방 생성 확인")
 public class ChatroomServiceTest {
 
+    /*
+        - 혹시 테스트 실패한다면 아마 PostEntity에서 상품 이미지를 List로 받아오기 때문
+        - 현재는 ChatroomException까지 잘 동작
+    */
+
     @Autowired
     private ChatroomService chatroomService;
 
     @Test
     @DisplayName("개인 채팅방 생성 완료")
     void CREATE_CHATROOM_TEST() {
-        ChatroomCreateRequest chatroomCreateRequest = ChatroomCreateRequest.builder().postId(2L).userId(3L).build();
+        ChatroomCreateRequest chatroomCreateRequest = ChatroomCreateRequest.builder().postId(2L).build();
 
-        ChatroomResponse chatroomResponse = chatroomService.createChatroom(chatroomCreateRequest);
+        ChatroomResponse chatroomResponse = chatroomService.createChatroom(chatroomCreateRequest, 3L);
 
         assertNotNull(chatroomResponse);
         assertNotNull(chatroomResponse.getChatroomId());

--- a/src/test/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomServiceTest.java
+++ b/src/test/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomServiceTest.java
@@ -14,11 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @DisplayName("개인 채팅방 생성 확인")
 public class ChatroomServiceTest {
 
-    /*
-        - 혹시 테스트 실패한다면 아마 PostEntity에서 상품 이미지를 List로 받아오기 때문
-        - 현재는 ChatroomException까지 잘 동작
-    */
-
     @Autowired
     private ChatroomService chatroomService;
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
기존에는 Stomp 연결 할 때 따로 헤더를 받아와서 JWT 유효성 검사를 진행하지는 않았는데 
이번에 StompHandler를 구현하여 jwt 검사를 추가하였습니다.

채팅 서비스에 들어오는 요청 하나하나 검사하는 것은 불필요하다 생각해서
채팅방 구독(SUBSCRIBE)과 웹소켓 연결(CONNECT) 시에만 검사하도록 구현했습니다.

(+) SecurityConfig에 웹소켓 엔드포인트도 추가하였습니다. 

**TO-BE**
- jwt 유효성 관련 exception 추가 
- 에러 메시지 전달 handler 구현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 

### 기타
아직 유저 생성 할 수 없어서 API 테스트는 진행하지 못 했습니다. 
배포 하고 다시 테스트 진행할 예정입니다.