### PR TITLE
Feature/#55 단체 채팅방 생성 구현

### DIFF
--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/event/GroupChatCreateEvent.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/event/GroupChatCreateEvent.java
@@ -1,0 +1,16 @@
+package com.ttodampartners.ttodamttodam.domain.chat.dto.event;
+
+import com.ttodampartners.ttodamttodam.domain.post.entity.PostEntity;
+import com.ttodampartners.ttodamttodam.domain.request.entity.RequestEntity;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class GroupChatCreateEvent {
+    private final PostEntity post;
+    private final List<RequestEntity> requestEntities;
+}

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/event/GroupChatCreateEvent.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/dto/event/GroupChatCreateEvent.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
-@AllArgsConstructor
 public class GroupChatCreateEvent {
     private final PostEntity post;
     private final List<RequestEntity> requestEntities;

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/repository/ChatroomRepository.java
@@ -3,6 +3,7 @@ package com.ttodampartners.ttodamttodam.domain.chat.repository;
 import com.ttodampartners.ttodamttodam.domain.chat.entity.ChatroomEntity;
 import com.ttodampartners.ttodamttodam.domain.post.entity.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +13,6 @@ import java.util.Optional;
 public interface ChatroomRepository extends JpaRepository<ChatroomEntity, Long> {
     Optional<ChatroomEntity> findByChatroomId(Long id);
     List<ChatroomEntity> findByPostEntity(PostEntity post);
+    @Query(nativeQuery = true, value = "SELECT * FROM CHATROOM WHERE post_id=? AND user_count > 2 LIMIT 1")
+    ChatroomEntity findByPostEntityAndUserCountGreaterThan2(PostEntity post);
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
@@ -108,7 +108,18 @@ public class ChatroomService {
         PostEntity post = event.getPost();
         List<RequestEntity> requestEntities = event.getRequestEntities();
 
+        // CHATROOM 테이블에 컬럼 추가
+        ChatroomEntity chatroom = chatroomRepository.save(
+                ChatroomEntity.builder().postEntity(post).chatName(post.getTitle()).userCount(requestEntities.size() + 1).build()
+        );
 
+        List<UserEntity> members = new ArrayList<>();
+        members.add(post.getUser());
+        requestEntities.stream().map(
+                request -> members.add(request.getRequestUser())
+        );
+
+        saveChatroomMembers(members, chatroom);
     }
 
     // 유저가 속한 채팅방 목록 조회 -> List 반환

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomService.java
@@ -1,6 +1,7 @@
 package com.ttodampartners.ttodamttodam.domain.chat.service;
 
 import com.ttodampartners.ttodamttodam.domain.chat.dto.ChatExceptionResponse;
+import com.ttodampartners.ttodamttodam.domain.chat.dto.event.GroupChatCreateEvent;
 import com.ttodampartners.ttodamttodam.domain.chat.dto.request.ChatroomCreateRequest;
 import com.ttodampartners.ttodamttodam.domain.chat.dto.response.ChatroomExistedResponse;
 import com.ttodampartners.ttodamttodam.domain.chat.dto.response.ChatroomListResponse;
@@ -9,19 +10,24 @@ import com.ttodampartners.ttodamttodam.domain.chat.dto.response.ChatroomProfileR
 import com.ttodampartners.ttodamttodam.domain.chat.entity.ChatroomEntity;
 import com.ttodampartners.ttodamttodam.domain.chat.entity.ChatroomMemberEntity;
 import com.ttodampartners.ttodamttodam.domain.chat.exception.ChatroomException;
-import com.ttodampartners.ttodamttodam.domain.chat.exception.ChatroomStringException;
 import com.ttodampartners.ttodamttodam.domain.chat.repository.ChatroomMemberRepository;
 import com.ttodampartners.ttodamttodam.domain.chat.repository.ChatroomRepository;
 import com.ttodampartners.ttodamttodam.domain.post.entity.PostEntity;
 import com.ttodampartners.ttodamttodam.domain.post.repository.PostRepository;
+import com.ttodampartners.ttodamttodam.domain.request.entity.RequestEntity;
 import com.ttodampartners.ttodamttodam.domain.user.entity.UserEntity;
 import com.ttodampartners.ttodamttodam.domain.user.exception.UserException;
 import com.ttodampartners.ttodamttodam.domain.user.repository.UserRepository;
 import com.ttodampartners.ttodamttodam.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
@@ -30,6 +36,7 @@ import java.util.List;
 
 import static com.ttodampartners.ttodamttodam.global.error.ErrorCode.*;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ChatroomService {
@@ -38,7 +45,6 @@ public class ChatroomService {
     private final ChatroomRepository chatroomRepository;
     private final ChatroomMemberRepository chatroomMemberRepository;
 
-    // 일대일 개인 채팅방 생성 -> response body 반환
     // 추후 게시글 상태 '모집중'인지 체크!!
     @Transactional
     public ChatroomResponse createChatroom(ChatroomCreateRequest request, Long userId) {
@@ -92,6 +98,19 @@ public class ChatroomService {
                 .build();
     }
 
+    // 단체 채팅방 생성
+    @Async // 이벤트 메서드를 새로운 스레드에서 실행
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createGroupChat(GroupChatCreateEvent event) {
+        log.info("TransactionPhase.AFTER_COMMIT ---> {}", event);
+
+        PostEntity post = event.getPost();
+        List<RequestEntity> requestEntities = event.getRequestEntities();
+
+
+    }
+
     // 유저가 속한 채팅방 목록 조회 -> List 반환
     @Transactional
     public List<ChatroomListResponse> getChatrooms(Long userId) {
@@ -106,6 +125,7 @@ public class ChatroomService {
 
         return userChatrooms.stream().map(ChatroomMemberEntity::getChatroomInfos).toList();
     }
+
 
     /*
         채팅방에 소속된 유저들 관련 메소드

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/request/service/RequestService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/request/service/RequestService.java
@@ -111,17 +111,22 @@ public class RequestService {
         if (acceptedRequestsCount == post.getParticipants()) {
             post.setStatus(PostEntity.Status.COMPLETED);
 
-            /*
-                단체 채팅방 생성을 위한 event publish
-             */
-            eventPublisher.publishEvent(GroupChatCreateEvent.builder().post(post).requestEntities(requests).build());
-
             // 남은 모든 요청들의 상태를 거절로 변경
             for (RequestEntity request : requests) {
                 if (request.getRequestStatus() == RequestEntity.RequestStatus.WAIT) {
                     request.setRequestStatus(RequestEntity.RequestStatus.REFUSE);
                 }
             }
+
+            /*
+                단체 채팅방 생성을 위한 event publish
+             */
+            eventPublisher.publishEvent(
+                    GroupChatCreateEvent.builder()
+                    .post(post)
+                    .requestEntities(requests.stream()
+                    .filter(request -> request.getRequestStatus() == RequestEntity.RequestStatus.ACCEPT).toList()).build()
+            );
         }
     }
 

--- a/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
   Chatroom Exception
    */
   CHATROOM_ALREADY_EXIST("개인 채팅방이 이미 존재합니다."),
+  GROUP_CHATROOM_ALREADY_EXIST("단체 채팅방이 이미 존재합니다."),
   USER_CHATROOM_NOT_EXIST("해당 유저가 속한 채팅방이 존재하지 않습니다."),
   USER_NOT_IN_CHATROOM("해당 유저가 채팅방에 속해있지 않아 채팅방을 나갈 수 없습니다."),
   CHATROOM_NOT_FOUND("채팅방이 존재하지 않습니다."),


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
단체 채팅방 생성 로직을 구현했습니다. 

RequestService > updatePostStatus 메소드에 event publisher 추가 되었고,
ChatroomService에 createGroupChat 메소드로 단체 채팅방 생성 로직이 구현되었습니다.

**TO-BE**
아직 API 테스트를 수행할 수 없어 자세한 예외 처리는 배포 이후 추가될 예정입니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 