### PR TITLE
Refactor/#35 채팅방 나가기 기능 업데이트 및 오류 수정

### DIFF
--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatController.java
@@ -68,20 +68,22 @@ public class ChatController {
         채팅방에서 완전히 나간 유저가 있으면 알려줌
      */
     @MessageMapping("/user-exit")
-    public void sendExitMessage(@RequestParam("chatroomId") Long chatroomId, @RequestParam("leftUserNickname") String leftNickname) {
+    public void sendExitMessage(@RequestParam("chatroomId") Long chatroomId, @RequestParam("leftUserId") Long leftUserId) {
         ChatroomEntity chatroom = chatroomRepository.findByChatroomId(chatroomId).orElseThrow(() -> new ChatroomStringException(ErrorCode.CHATROOM_NOT_FOUND));
+
+        UserEntity leftUser = userRepository.findById(leftUserId).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
 
         List<ChatroomMemberEntity> remainUsers = chatroomMemberRepository.findAllByChatroomEntity(chatroom);
         String message;
         if (remainUsers.size() == 1) {
-            message = String.format("[%s]님이 채팅방에서 나갔습니다. 더이상 해당 채팅방을 이용할 수 없습니다.", leftNickname);
+            message = String.format("[%s]님이 채팅방에서 나갔습니다. 더이상 해당 채팅방을 이용할 수 없습니다.", leftUser.getNickname());
         } else {
-            message = String.format("[%s]님이 채팅방에서 나갔습니다.", leftNickname);
+            message = String.format("[%s]님이 채팅방에서 나갔습니다.", leftUser.getNickname());
         }
 
-        chatService.saveChatMessage(chatroomId, ChatMessageRequest.builder().content(message).build(), null);
+        chatService.saveChatMessage(chatroomId, ChatMessageRequest.builder().nickname("LEFT USER").content(message).build(), leftUserId);
         simpMessagingTemplate.convertAndSend("/chatroom/" + chatroomId, message);
 
-        log.info("User nickname [{}] left the chatroom [id: {}]", leftNickname, chatroomId);
+        log.info("User nickname [{}] left the chatroom [id: {}]", leftUser.getNickname(), chatroomId);
     }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatController.java
@@ -79,6 +79,7 @@ public class ChatController {
             message = String.format("[%s]님이 채팅방에서 나갔습니다.", leftNickname);
         }
 
+        chatService.saveChatMessage(chatroomId, ChatMessageRequest.builder().content(message).build(), null);
         simpMessagingTemplate.convertAndSend("/chatroom/" + chatroomId, message);
 
         log.info("User nickname [{}] left the chatroom [id: {}]", leftNickname, chatroomId);

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatroomController.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatroomController.java
@@ -29,6 +29,7 @@ public class ChatroomController {
     private final ChatroomCreateService chatroomCreateService;
     private final ChatroomLeaveService chatroomLeaveService;
     private final UserRepository userRepository;
+    private final ChatController chatController;
 
     @PostMapping // POST /chatrooms (채팅방 생성)
     public ResponseEntity<ChatroomResponse> createChatroom(@RequestBody ChatroomCreateRequest request, @AuthenticationPrincipal UserDetailsDto userDetailsDto) {
@@ -46,9 +47,13 @@ public class ChatroomController {
     }
 
     @DeleteMapping("/{chatroomId}/exit") // DELETE /chatrooms/{chatroomId}/exit (채팅방 나가기)
-    public void leaveChatroom(@PathVariable Long chatroomId, @AuthenticationPrincipal UserDetailsDto userDetailsDto) {
+    public ResponseEntity<String> leaveChatroom(@PathVariable Long chatroomId, @AuthenticationPrincipal UserDetailsDto userDetailsDto) {
         Long leftUserId = userDetailsDto.getId();
         UserEntity user = userRepository.findById(leftUserId).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
         chatroomLeaveService.leaveChatroom(chatroomId, leftUserId);
+
+        chatController.sendExitMessage(chatroomId, user.getNickname());
+
+        return ResponseEntity.ok("정상적으로 채팅방 나가기가 수행되었습니다.");
     }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatroomController.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/controller/ChatroomController.java
@@ -52,7 +52,7 @@ public class ChatroomController {
         UserEntity user = userRepository.findById(leftUserId).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
         chatroomLeaveService.leaveChatroom(chatroomId, leftUserId);
 
-        chatController.sendExitMessage(chatroomId, user.getNickname());
+        chatController.sendExitMessage(chatroomId, leftUserId);
 
         return ResponseEntity.ok("정상적으로 채팅방 나가기가 수행되었습니다.");
     }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/entity/ChatroomEntity.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/entity/ChatroomEntity.java
@@ -48,4 +48,8 @@ public class ChatroomEntity extends BaseEntity {
     public void updateLastMessage(Long lastMessageId) {
         this.lastMessageId = lastMessageId;
     }
+
+    public void updateUserCount() {
+        this.userCount -= 1;
+    }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomCreateService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomCreateService.java
@@ -60,6 +60,10 @@ public class ChatroomCreateService {
         // 게시글 작성자
         UserEntity host = userRepository.findById(post.getUser().getId()).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
 
+        if (host.getId().equals(user.getId())) {
+            throw new ChatroomStringException("게시글 작성자입니다.");
+        }
+
         // 이미 user가 해당 post에 일대일 채팅방 생성한 적 있는지 체크
         List<ChatroomEntity> chatroomEntities = chatroomRepository.findByPostEntity(post); // 이 post에서 생성된 채팅방 리스트
         ErrorCode code = CHATROOM_ALREADY_EXIST;

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomEnterService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomEnterService.java
@@ -35,8 +35,6 @@ public class ChatroomEnterService {
 
         if (CollectionUtils.isEmpty(chatroomMemberEntities)) {
             throw new ChatroomStringException("채팅방에 소속된 유저가 없습니다.");
-        } else if (chatroomMemberEntities.size() != chatroom.getUserCount()) {
-            log.info("채팅방 인원 수에 차이가 있습니다. 채팅방에서 나간 유저가 있는지 확인해주세요.");
         }
 
         List<ChatroomProfileResponse> profileList = chatroomMemberEntities.stream().map(
@@ -55,9 +53,7 @@ public class ChatroomEnterService {
         }
 
         List<ChatMessageEntity> chatMessageEntities = chatMessageRepository.findAllByChatroomEntity(chatroom);
-        List<ChatMessageResponse> chatMessageResponses = chatMessageEntities.stream().map(
-                ChatMessageEntity::getChatMessageResponse
-        ).toList();
-        return chatMessageResponses;
+
+        return chatMessageEntities.stream().map(ChatMessageEntity::getChatMessageResponse).toList();
     }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomLeaveService.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/domain/chat/service/ChatroomLeaveService.java
@@ -8,7 +8,9 @@ import com.ttodampartners.ttodamttodam.domain.chat.exception.ChatroomStringExcep
 import com.ttodampartners.ttodamttodam.domain.chat.repository.ChatroomMemberRepository;
 import com.ttodampartners.ttodamttodam.domain.chat.repository.ChatroomRepository;
 import com.ttodampartners.ttodamttodam.domain.user.entity.UserEntity;
+import com.ttodampartners.ttodamttodam.domain.user.exception.UserException;
 import com.ttodampartners.ttodamttodam.domain.user.repository.UserRepository;
+import com.ttodampartners.ttodamttodam.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -29,12 +31,15 @@ public class ChatroomLeaveService {
     // 유저가 속한 chatroomId 채팅방 나가기
     @Transactional
     public void leaveChatroom(Long chatroomId, Long userId) {
-        UserEntity user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
+        UserEntity user = userRepository.findById(userId).orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
         ChatroomEntity chatroom = chatroomRepository.findByChatroomId(chatroomId).orElseThrow(() -> new ChatroomStringException(CHATROOM_NOT_FOUND));
 
         ChatroomMemberEntity userChatroom = chatroomMemberRepository.findByUserEntityAndChatroomEntity(user, chatroom).orElseThrow(
                 () -> new ChatroomException(USER_NOT_IN_CHATROOM, ChatExceptionResponse.res(HttpStatus.BAD_REQUEST, USER_NOT_IN_CHATROOM.getDescription()))
         );
+
+        // 채팅방 userCount -1
+        chatroom.updateUserCount();
 
         chatroomMemberRepository.delete(userChatroom);
 

--- a/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/global/error/ErrorCode.java
@@ -75,7 +75,7 @@ public enum ErrorCode {
   GROUP_CHATROOM_ALREADY_EXIST("단체 채팅방이 이미 존재합니다."),
   CHATROOM_CREATE_DENIED("채팅방 생성은 모집중 상태에만 가능합니다."),
   USER_CHATROOM_NOT_EXIST("해당 유저가 속한 채팅방이 존재하지 않습니다."),
-  USER_NOT_IN_CHATROOM("해당 유저가 채팅방에 속해있지 않아 채팅방을 나갈 수 없습니다."),
+  USER_NOT_IN_CHATROOM("해당 유저가 채팅방에 속해있지 않습니다."),
   CHATROOM_NOT_FOUND("채팅방이 존재하지 않습니다."),
   CHATROOM_MESSAGE_NOT_FOUND("이전 채팅 기록이 존재하지 않습니다."),
   /*

--- a/src/main/java/com/ttodampartners/ttodamttodam/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/global/error/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -74,12 +75,6 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getErrorMessage());
   }
 
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<String> validationExceptionHandle(MethodArgumentNotValidException e) {
-    String errorMessage = e.getBindingResult().getFieldError().getDefaultMessage();
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
-  }
-
   /*
     게시글 관련 Exception 추가
   */
@@ -99,5 +94,20 @@ public class GlobalExceptionHandler {
   public ResponseEntity<String> BookmarkExceptionHandle(BookmarkException e) {
     log.error("에러코드: {}, 에러 메시지: {}", e.getErrorCode(), e.getErrorMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getErrorMessage());
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<String> validationExceptionHandle(MethodArgumentNotValidException e) {
+    String errorMessage = e.getBindingResult().getFieldError().getDefaultMessage();
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMessage);
+  }
+
+  /*
+    파일 크기가 1MB 보다 큰 경우 예외 처리
+   */
+  @ExceptionHandler({MaxUploadSizeExceededException.class})
+  protected ResponseEntity<String> handleMultipartException(MaxUploadSizeExceededException e) {
+    log.error("에러코드: MaxUploadSizeExceededException, 에러 메시지: {}", e.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("1MB 미만의 파일만 업로드 가능합니다.");
   }
 }

--- a/src/main/java/com/ttodampartners/ttodamttodam/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/ttodampartners/ttodamttodam/global/error/GlobalExceptionHandler.java
@@ -103,11 +103,14 @@ public class GlobalExceptionHandler {
   }
 
   /*
-    파일 크기가 1MB 보다 큰 경우 예외 처리
+    파일 크기가 1MB 보다 큰 경우(FileSizeLimitExceededException),
+    하나의 요청이 기본 설정된 최대 용량을 초과했을 때(SizeLimitExceededException)
+    발생하는 예외 처리
    */
   @ExceptionHandler({MaxUploadSizeExceededException.class})
   protected ResponseEntity<String> handleMultipartException(MaxUploadSizeExceededException e) {
     log.error("에러코드: MaxUploadSizeExceededException, 에러 메시지: {}", e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("1MB 미만의 파일만 업로드 가능합니다.");
   }
+
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- **채팅방 나가기 기능 업데이트**
  - 여기서 `채팅방 나가기`는 웹소켓 DISCONNECT가 아닌 카카오톡에서 단톡방 나가기 기능 생각하면 됩니다.
  - 한 유저가 채팅방 나갈 시 해당 채팅방에 `[유저 닉네임]님이 채팅방에서 나갔습니다.`는 웹소켓 메시지 발송
  - 만약 해당 채팅방에 인원이 1명만 남게 될 경우 `[유저 닉네임]님이 채팅방에서 나갔습니다. 더이상 해당 채팅방을 이용할 수 없습니다.`는 웹소켓 메시지 발송

- **개인 채팅방 생성 부분 예외 처리 추가**
  - 게시글 작성자가 본인 게시글에 개인 채팅방 생성 request를 보낼 경우 예외 처리 

- **이미지 업로드 시 용량 관련 예외 처리 추가**
  - 기존에는 1MB 이상의 이미지를 request에서 받을 경우 `403` 에러와 함께 **서버에서만 `FileSizeLimitExceededException` 에러 메시지를 확인할 수 있었습니다.**
  - 클라이언트에서는 어떤 것이 원인인지 알 수 없기 때문에 `GlobalExceptionHandler`에 관련 예외 처리를 추가했습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 